### PR TITLE
compat: Removed incompatibility flag for disable-cargo-drops-techs

### DIFF
--- a/info.json
+++ b/info.json
@@ -7,8 +7,7 @@
     "dependencies": ["base >= 2.0",
         "space-age >= 2.0.26",
         "PlanetsLib >= 1.4.1",
-        "rubia-assets >= 0.69.8",
-        "! disable-cargo-drops-techs"
+        "rubia-assets >= 0.69.8"
     ],
     "space_travel_required": true,
     "description": "Discover the wind planet Rubia. Belts and inserters work differently on Rubia, leading to unique building challenges not seen on any other planet. Your whole factory must go with the wind as a never-ending barrage of waste is hurled at your base.",


### PR DESCRIPTION
Removed incompatibility flag for disable-cargo-drops-techs, as Rubia's cargo drop technology is no longer removed when Rubia is installed.